### PR TITLE
[pacboy] support argument ':p', which uses envvar MINGW_PACKAGE_PREFIX

### DIFF
--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -20,6 +20,7 @@ help_and_exit() {
             name:c means clang-x86_64-only
             name:u means ucrt-x86_64-only
             name:a means clang-aarch64-only
+            name:p means MINGW_PACKAGE_PREFIX-only
 
         For MSYS shell:
             name:m means mingw-w64
@@ -215,6 +216,7 @@ for argument in "${arguments[@]}"; do
      *:c) raw_argument=(mingw-w64-clang-x86_64-${argument%:c}) ;;
      *:l) raw_argument=(mingw-w64-clang-x86_64-${argument%:l} mingw-w64-clang-i686-${argument%:l}) ;;
      *:a) raw_argument=(mingw-w64-clang-aarch64-${argument%:a}) ;;
+     *:p) raw_argument=(${MINGW_PACKAGE_PREFIX}-${argument%:p}) ;;
      *) parse_mingw_argument ;;
     esac
     [[ $argument =~ ^(-h|-[^-].*h|--help$) ]] && help_tip='true'


### PR DESCRIPTION
This option allows installing packages for "the current environment", without explicitly specifying it.

See msys2/setup-msys2#166 for an explanation of the use case, including examples and CI tests.