### PR TITLE
Make pacboy work the same in all envs and only ever map to one package

### DIFF
--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -2,7 +2,7 @@
 
 help_and_exit() {
     echo "
-    Pacboy 2016.6.24
+    Pacboy 2024.05.10
     Copyright (C) 2015, 2016 Renato Silva
     Licensed under BSD
 

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -161,6 +161,7 @@ machine=$(uname -m)
 case "${MSYSTEM}" in
     MINGW32) architecture='i686' ;;
     MINGW64) architecture='x86_64' ;;
+    CLANG32) architecture='clang-i686' ;;
     CLANG64) architecture='clang-x86_64' ;;
     UCRT64) architecture='ucrt-x86_64' ;;
     *) architecture="${machine}"

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -22,10 +22,6 @@ help_and_exit() {
             name:a means clang-aarch64-only
             name:p means MINGW_PACKAGE_PREFIX-only
 
-        For MSYS shell:
-            name:m means mingw-w64
-            name:l means mingw-w64-clang
-
         For all shells:
             name: disables any translation for name
             repository::name means repository/name
@@ -75,6 +71,15 @@ status() {
         local normal='\e[0m'
     fi
     echo -e "${blue}::${white}" "${@}...${normal}"
+}
+
+warning() {
+    if [[ -t 1 ]]; then
+        local yellow='\e[1;33m'
+        local white='\e[1;37m'
+        local normal='\e[0m'
+    fi
+    echo -e "${yellow}warning:${white}" "${@}${normal}"
 }
 
 execute() {
@@ -200,11 +205,19 @@ for argument in "${arguments[@]}"; do
       *:) raw_argument=("${argument%:}") ;;
      *:i) raw_argument=(mingw-w64-i686-${argument%:i}) ;;
      *:x) raw_argument=(mingw-w64-x86_64-${argument%:x}) ;;
-     *:m) raw_argument=(mingw-w64-x86_64-${argument%:m} mingw-w64-i686-${argument%:m}) ;;
+     *:m)
+        # deprecated
+        warning "'${argument}' is deprecated, use '${argument%:m}:i' and/or '${argument%:m}:x' instead"
+        raw_argument=(mingw-w64-x86_64-${argument%:m} mingw-w64-i686-${argument%:m})
+        ;;
      *:u) raw_argument=(mingw-w64-ucrt-x86_64-${argument%:u}) ;;
      *:z) raw_argument=(mingw-w64-clang-i686-${argument%:z}) ;;
      *:c) raw_argument=(mingw-w64-clang-x86_64-${argument%:c}) ;;
-     *:l) raw_argument=(mingw-w64-clang-x86_64-${argument%:l} mingw-w64-clang-i686-${argument%:l}) ;;
+     *:l)
+        # deprecated
+        warning "'${argument}' is deprecated, use '${argument%:l}:z' and/or '${argument%:c}:x' instead"
+        raw_argument=(mingw-w64-clang-x86_64-${argument%:l} mingw-w64-clang-i686-${argument%:l})
+        ;;
      *:a) raw_argument=(mingw-w64-clang-aarch64-${argument%:a}) ;;
      *:p) raw_argument=(${full_package_prefix}${argument%:p}) ;;
      *) parse_mingw_argument ;;

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -13,7 +13,7 @@ help_and_exit() {
         $(basename "$0") [command] [arguments]
         Arguments will be passed to pacman after translation:
 
-        For 64-bit MSYS2 shell:
+        Package name translations:
             name:i means i686-only
             name:x means x86_64-only
             name:z means clang-i686-only
@@ -21,8 +21,6 @@ help_and_exit() {
             name:u means ucrt-x86_64-only
             name:a means clang-aarch64-only
             name:p means MINGW_PACKAGE_PREFIX-only
-
-        For all shells:
             name: disables any translation for name
             repository::name means repository/name
 

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -54,7 +54,7 @@ parse_mingw_argument() {
     [[ "${command}"  = packages ]] && { raw_argument=(${argument}); return; }
     [[ "${command}"  = files    ]] && { raw_argument=(${full_package_prefix}${argument}); return; }
     [[ "${command}"  = info     ]] && { raw_argument=(${full_package_prefix}${argument}); return; }
-    raw_argument=(mingw-w64-x86_64-${argument} mingw-w64-i686-${argument})
+    raw_argument=(${full_package_prefix}${argument})
 }
 
 realname() {

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -53,7 +53,6 @@ parse_mingw_argument() {
     [[ "${command}"  = find     ]] && { raw_argument=(${argument}); return; }
     [[ "${command}"  = packages ]] && { raw_argument=(${argument}); return; }
     [[ "${MSYSTEM}" != MINGW*   ]] && { raw_argument=(${argument}); return; }
-    [[ "${machine}" != x86_64   ]] && { raw_argument=(mingw-w64-${architecture}-${argument}); return; }
     [[ "${command}"  = files    ]] && { raw_argument=(mingw-w64-${architecture}-${argument}); return; }
     [[ "${command}"  = info     ]] && { raw_argument=(mingw-w64-${architecture}-${argument}); return; }
     raw_argument=(mingw-w64-x86_64-${argument} mingw-w64-i686-${argument})

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -14,15 +14,16 @@ help_and_exit() {
         Arguments will be passed to pacman after translation:
 
         Package name translations:
-            name:i means i686-only
-            name:x means x86_64-only
-            name:z means clang-i686-only
-            name:c means clang-x86_64-only
-            name:u means ucrt-x86_64-only
-            name:a means clang-aarch64-only
-            name:p means MINGW_PACKAGE_PREFIX-only
-            name: disables any translation for name
-            repository::name means repository/name
+            name   - uses the package prefix of the current environment: ${full_package_prefix}name
+            name:i - translates to mingw-w64-i686-name
+            name:x - translates to mingw-w64-x86_64-name
+            name:z - translates to mingw-w64-clang-i686-name
+            name:c - translates to mingw-w64-clang-x86_64-name
+            name:u - translates to mingw-w64-ucrt-x86_64-name
+            name:a - translates to mingw-w64-clang-aarch64-name
+            name:p - means the same as \"name\"
+            name:  - disables any translation for name
+            repository::name - means repository/name
 
     Commands:
         sync        Shorthand for --sync or --upgrade

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -52,9 +52,8 @@ parse_mingw_argument() {
     [[ "${command}"  = origin   ]] && { raw_argument=(${argument}); return; }
     [[ "${command}"  = find     ]] && { raw_argument=(${argument}); return; }
     [[ "${command}"  = packages ]] && { raw_argument=(${argument}); return; }
-    [[ "${MSYSTEM}" != MINGW*   ]] && { raw_argument=(${argument}); return; }
-    [[ "${command}"  = files    ]] && { raw_argument=(mingw-w64-${architecture}-${argument}); return; }
-    [[ "${command}"  = info     ]] && { raw_argument=(mingw-w64-${architecture}-${argument}); return; }
+    [[ "${command}"  = files    ]] && { raw_argument=(${full_package_prefix}${argument}); return; }
+    [[ "${command}"  = info     ]] && { raw_argument=(${full_package_prefix}${argument}); return; }
     raw_argument=(mingw-w64-x86_64-${argument} mingw-w64-i686-${argument})
 }
 
@@ -156,15 +155,7 @@ refresh_databases() {
 arguments=()
 raw_arguments=()
 pacman='pacman --color auto'
-machine=$(uname -m)
-case "${MSYSTEM}" in
-    MINGW32) architecture='i686' ;;
-    MINGW64) architecture='x86_64' ;;
-    CLANG32) architecture='clang-i686' ;;
-    CLANG64) architecture='clang-x86_64' ;;
-    UCRT64) architecture='ucrt-x86_64' ;;
-    *) architecture="${machine}"
-esac
+full_package_prefix="${MINGW_PACKAGE_PREFIX:+${MINGW_PACKAGE_PREFIX}-}"
 test -z "${1}" && help_and_exit
 
 for argument in "${@}"; do
@@ -215,7 +206,7 @@ for argument in "${arguments[@]}"; do
      *:c) raw_argument=(mingw-w64-clang-x86_64-${argument%:c}) ;;
      *:l) raw_argument=(mingw-w64-clang-x86_64-${argument%:l} mingw-w64-clang-i686-${argument%:l}) ;;
      *:a) raw_argument=(mingw-w64-clang-aarch64-${argument%:a}) ;;
-     *:p) raw_argument=(${MINGW_PACKAGE_PREFIX:+${MINGW_PACKAGE_PREFIX}-}${argument%:p}) ;;
+     *:p) raw_argument=(${full_package_prefix}${argument%:p}) ;;
      *) parse_mingw_argument ;;
     esac
     [[ $argument =~ ^(-h|-[^-].*h|--help$) ]] && help_tip='true'

--- a/source/pacboy/pacboy.sh
+++ b/source/pacboy/pacboy.sh
@@ -23,7 +23,7 @@ help_and_exit() {
             name:a - translates to mingw-w64-clang-aarch64-name
             name:p - means the same as \"name\"
             name:  - disables any translation for name
-            repository::name - means repository/name
+            repository::name - means repository/name (the name part gets translated as above)
 
     Commands:
         sync        Shorthand for --sync or --upgrade


### PR DESCRIPTION
This fixes #4, see the commits for details. I tried to split it up as best as I can.

Summary:

* All environments work the same now
* MINGW32/64 fallback will now defaults to "name:p" instead of "name:m"
* Fallback for all others will now default to "name:p" instead of "name:"
* "name:l" and "name:m" are now deprecated
